### PR TITLE
Increase msg timeout

### DIFF
--- a/Hosts_Update.cmd
+++ b/Hosts_Update.cmd
@@ -11,7 +11,7 @@ rem Enable delayed expansion to be used during for loops and other parenthetical
 setlocal ENABLEDELAYEDEXPANSION
 
 rem Script version number
-set V=1.33
+set V=1.34
 
 rem Set Resource and target locations
 set CACHE=Unified-Hosts-AutoUpdate

--- a/Hosts_Update.cmd
+++ b/Hosts_Update.cmd
@@ -646,7 +646,7 @@ if %QUIET%==1 if not %EXIT%==0 (
 		echo ***** Unified Hosts AutoUpdate *****
 		echo.
 		echo ERROR: %ERROR%^^!
-	) | msg *
+	) | msg * /time:86400
 )
 
 rem Clean up temporary files if they exist


### PR DESCRIPTION
The [msg docs](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/msg#parameters) say:
> If no time limit is set, the message remains on the user's screen until the user sees the message and clicks OK

Unfortunately, that's wrong, and when `/time` isn't specified, the message actually disappears after about a minute (at least on my Windows 10 machine [1909]). This misses the entire point of the notification, which is to notify you when something went wrong while you were sleeping and the update was supposed to take place at 3 AM.

This change increases the time limit to 24 hours (86400 seconds), at which point the task would run again anyway (producing a new notification, ad infinitum until the user notices).